### PR TITLE
ogn-rf: Detect if stdin is a terminal

### DIFF
--- a/ogn-rf.cc
+++ b/ogn-rf.cc
@@ -1055,10 +1055,17 @@ int main(int argc, char *argv[])
   GSM.Start();
   RF.Start();
 
-  char Cmd[128];
-  while(!RF.StopReq)
-  { if(fgets(Cmd, 128, stdin)==0) break;
-    UserCommand(Cmd); }
+  if (isatty(fileno(stdin))) {
+    char Cmd[128];
+    while(!RF.StopReq) {
+      if(fgets(Cmd, 128, stdin)==0) break;
+      UserCommand(Cmd);
+    }
+  } else {
+    while(!RF.StopReq) {
+      sleep(1);
+    }
+  }
 
   sleep(4);
   RF.Stop();


### PR DESCRIPTION
Fixes #11: Version 0.2.5 crashs with SEGV if invoked by systemd.