### PR TITLE
Clang error cleanup

### DIFF
--- a/r2fft_test.cc
+++ b/r2fft_test.cc
@@ -5,6 +5,7 @@
 #include "fft.h"
 
 #define Float double
+#define FFTsize 1024
 
 template <class Type>
  double Power(std::complex<Type> X)
@@ -15,7 +16,6 @@ int main(int argc, char *argv[])
   r2FFT<Float> FFT;
   DFT1d<Float> RefFFT;
 
-  int FFTsize = 1024;
   std::complex<Float> Buffer[FFTsize];
 
   FFT.Preset(FFTsize);

--- a/socket.h
+++ b/socket.h
@@ -162,7 +162,7 @@ class SocketBuffer             // data buffer for IP sockets
      { if(Data) { free(Data); Data=0; }
        Allocated=0; Len=0; Done=0; }
 
-   size_t Relocate(size_t Size)
+   size_t Relocate(size_t Size) // Returns 0 on failure
      { if(Size<=Allocated) return Allocated;
        // printf("Relocate(%d)",Size);
        size_t Units=(Size+AllocUnit-1)/AllocUnit; Size=Units*AllocUnit;
@@ -199,7 +199,7 @@ class SocketBuffer             // data buffer for IP sockets
      { FILE *File = fopen(FileName,"r"); if(File==0) return -1;
        int Total=0;
        for( ; ; )
-       { if(Relocate(Len+AllocUnit)<0) { fclose(File); return -1; }
+       { if(Relocate(Len+AllocUnit)==0) { fclose(File); return -1; }
          int ToRead = Allocated-Len;
          int Read = fread(Data+Len, 1, ToRead, File);
          if(Read<0) { fclose(File); return -1; }


### PR DESCRIPTION
Fixed a warning and an error. Warning was a tautological comparison, and the error was creating a variable-sized array of a non-POD data type (std::complex).